### PR TITLE
feature: agol-validator verification

### DIFF
--- a/.github/ISSUE_TEMPLATE/introduce-sgid-dataset.md
+++ b/.github/ISSUE_TEMPLATE/introduce-sgid-dataset.md
@@ -83,7 +83,7 @@ assign yourself or someone to check that the dataset is live in its area. once v
 - [ ] Stewardship doc and sgid-index (@assigned on ``)
 - [ ] `SGID.META.AGOLItems` (@assigned on ``)
 - [ ] `SGID.META.ChangeDetection` (@assigned on ``)
-- [ ] `agol-validator` items (tags, thumbnail, etc) (@assgined on ``)
+- [ ] [agol-validator](https://github.com/agrc/agol-validator) items (@assgined on ``)
 
 
 # Notification

--- a/.github/ISSUE_TEMPLATE/introduce-sgid-dataset.md
+++ b/.github/ISSUE_TEMPLATE/introduce-sgid-dataset.md
@@ -83,6 +83,7 @@ assign yourself or someone to check that the dataset is live in its area. once v
 - [ ] Stewardship doc and sgid-index (@assigned on ``)
 - [ ] `SGID.META.AGOLItems` (@assigned on ``)
 - [ ] `SGID.META.ChangeDetection` (@assigned on ``)
+- [ ] `agol-validator` items (tags, thumbnail, etc) (@assgined on ``)
 
 
 # Notification


### PR DESCRIPTION
Add a step to verify the various `agol-validator` fixes have been performed:

- Tags (removes 'Utah' and any other tags in the item title, adds 'AGRC', 'SGID', and category tags, Proper Cases or CAPS tags)
- Checks title against meta table
- Checks folder and sharing groups against SGID group
- Enables downloads in all formats
- Enables delete protection
- Tries to update AGOL metadata from SDE metadata
- Adds static/shelved note to description if applicable
- Adds an AGRC-branded, category-specific thumbnail for SGID items
- Sets authoritative status against meta table.

Closes #39 