### PR TITLE
fix: prevent docker build from aborting apt-get commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 
 RUN curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list
 
-RUN apt-get update && apt-get upgrade
+RUN apt-get update -y && apt-get upgrade -y
 
 RUN ACCEPT_EULA=Y apt-get install unixodbc-dev unixodbc-dev libpq-dev msodbcsql17 -y --no-install-recommends
 


### PR DESCRIPTION
I was getting this error and was unable to build successfully:
![image](https://user-images.githubusercontent.com/1326248/99463872-ff47ed80-28f3-11eb-9d12-4230abf5e1bb.png)
