### PR TITLE
Gracefully handle check initialization exceptions

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -4,3 +4,4 @@ max-line-length=120
 disable=bad-continuation,broad-except
 ignore-patterns=test_.*?py
 ignore=connections_sample.py
+max-statements=55

--- a/pylintrc
+++ b/pylintrc
@@ -3,4 +3,4 @@ load-plugins=pylint_quotes
 max-line-length=120
 disable=bad-continuation,broad-except
 ignore-patterns=test_.*?py
-ignore = connections_sample.py
+ignore=connections_sample.py

--- a/src/conductor/conductor.py
+++ b/src/conductor/conductor.py
@@ -129,7 +129,7 @@ def write_reports(conductor_issues, secrets):
                 # pylint: disable=cell-var-from-loop
                 try:
                     yield
-                except Exception as exception:
+                except Exception:
                     print_exc()
                     reports[table].append(Report(report_name, issue, 'Exception was thrown!', error_report_grader))
                 finally:

--- a/src/conductor/conductor.py
+++ b/src/conductor/conductor.py
@@ -205,7 +205,7 @@ def publish_grades(all_grades, is_production):
             issue.create_comment(comment)
             print(f'comment left on issue {Fore.CYAN}{issue.title}{Fore.RESET}')
         else:
-            print(f'comment below would be posted to issue: "{issue.title}" in production')
+            print(f'\ncomment below would be posted to issue: "{issue.title}" in production')
             print(comment)
 
     return comments

--- a/src/conductor/conductor.py
+++ b/src/conductor/conductor.py
@@ -131,7 +131,7 @@ def write_reports(conductor_issues, secrets):
                     yield
                 except Exception as exception:
                     print_exc()
-                    reports[table].append(Report(report_name, issue, str(exception), error_report_grader))
+                    reports[table].append(Report(report_name, issue, 'Exception was thrown!', error_report_grader))
                 finally:
                     print(f'{Fore.GREEN}{report_name}{Fore.RESET} punched')
 


### PR DESCRIPTION
This was spurred by the table checks connection to the database which short-circuited the entire app. Here's what it would post with these changes if it was run today (without a connection to SGID/Internal):

comment below would be posted to issue: "Add combined Wilderness layer to SGID from BLM and USFS" in production
## conductor results for tasks - 100

| check | status |
| - | :-: |
| @gregbunce has completed **0** out of **1** tasks | :no_entry: |
| @steveoh has completed **0** out of **3** tasks | :no_entry: |
| @rkelson has completed **0** out of **1** tasks | :no_entry: |
| @ZachBeck has completed **2** out of **8** tasks | :no_entry: |
| @jacobdadams has completed **0** out of **1** tasks | :no_entry: |

comment below would be posted to issue: "Add combined Wilderness layer to SGID from BLM and USFS" in production
## conductor results for BOUNDARIES.UtahWildernessAreas

| check | status |
| - | :-: |
| internal sgid | ('HYT00', '[HYT00] [Microsoft][ODBC Driver 17 for SQL Server]Login timeout expired (0) (SQLDriverConnect)') |
| sgid10 | ('HYT00', '[HYT00] [Microsoft][ODBC Driver 17 for SQL Server]Login timeout expired (0) (SQLDriverConnect)') |
| meta table | ('HYT00', '[HYT00] [Microsoft][ODBC Driver 17 for SQL Server]Login timeout expired (0) (SQLDriverConnect)') |
| stewardship | 'NoneType' object has no attribute 'open_by_key' |

comment below would be posted to issue: "Remove BOUNDARIES.USFSWilderness from SGID" in production
## conductor results for tasks - 99

| check | status |
| - | :-: |
| @gregbunce has completed **0** out of **1** tasks | :no_entry: |
| @steveoh has completed **0** out of **5** tasks | :no_entry: |
| rkelson has completed **1** out of **1** tasks | :+1: |
| @ZachBeck has completed **0** out of **10** tasks | :no_entry: |
| @jacobdadams has completed **0** out of **1** tasks | :no_entry: |

comment below would be posted to issue: "Remove BOUNDARIES.USFSWilderness from SGID" in production
## conductor results for BOUNDARIES.USFSWilderness

| check | status |
| - | :-: |
| internal sgid | ('HYT00', '[HYT00] [Microsoft][ODBC Driver 17 for SQL Server]Login timeout expired (0) (SQLDriverConnect)') |
| sgid10 | ('HYT00', '[HYT00] [Microsoft][ODBC Driver 17 for SQL Server]Login timeout expired (0) (SQLDriverConnect)') |
| meta table | ('HYT00', '[HYT00] [Microsoft][ODBC Driver 17 for SQL Server]Login timeout expired (0) (SQLDriverConnect)') |
| stewardship | 'NoneType' object has no attribute 'open_by_key' |

comment below would be posted to issue: "Add Utah Quaternary Faults from UGS replacing existing faults in AGOL" in production
## conductor results for tasks - 75

| check | status |
| - | :-: |
| gregbunce has completed **2** out of **2** tasks | :+1: |
| @steveoh has completed **1** out of **3** tasks | :no_entry: |
| rkelson has completed **1** out of **1** tasks | :+1: |
| @stdavis has completed **2** out of **3** tasks | :no_entry: |
| @ZachBeck has completed **6** out of **7** tasks | :no_entry: |
| @jacobdadams has completed **0** out of **1** tasks | :no_entry: |