### PR TITLE
add geometry type to meta table checks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,3 +17,10 @@ show_capture = True
 minversion = 3.5
 console_output_style = count
 addopts = --pylint --cov-branch --cov=conductor --cov-report term --cov-report xml:cov.xml --instafail --isort
+filterwarnings =
+    ignore:Call to deprecated create function FieldDescriptor
+    ignore:Call to deprecated create function Descriptor
+    ignore:Call to deprecated create function EnumDescriptor
+    ignore:Call to deprecated create function EnumValueDescriptor
+    ignore:Call to deprecated create function FileDescriptor
+    ignore:Call to deprecated create function OneofDescriptor

--- a/src/conductor/checks.py
+++ b/src/conductor/checks.py
@@ -197,9 +197,11 @@ class MetaTableChecker(TableChecker):
         errors = []
         if not item_id:
             errors.append('missing item id')
-        elif not item_name:
+
+        if not item_name:
             errors.append('missing item name')
-        elif not geometry_type:
+
+        if not geometry_type:
             errors.append('missing geometry type')
 
         if len(errors) > 0:

--- a/src/conductor/checks.py
+++ b/src/conductor/checks.py
@@ -162,7 +162,7 @@ class PGSqlTableChecker(TableChecker):
 class MetaTableChecker(TableChecker):
     """meta table row checker
     """
-    sql = '''SELECT AGOL_ITEM_ID, AGOL_PUBLISHED_NAME
+    sql = '''SELECT AGOL_ITEM_ID, AGOL_PUBLISHED_NAME, GEOMETRY_TYPE
             FROM
                 SGID.META.AGOLITEMS
             WHERE
@@ -178,27 +178,34 @@ class MetaTableChecker(TableChecker):
         """
         item_id = None
         item_name = None
-        MetaResponse = namedtuple('MetaResponse', 'exists item_id item_name')
+        geometry_Type = None
+        MetaResponse = namedtuple('MetaResponse', 'exists item_id item_name geometry_type')
 
         TableChecker.get_data(self, (self.original_table))
 
         if self.data is None:
-            self.data = MetaResponse(False, item_id, item_name)
+            self.data = MetaResponse(False, item_id, item_name, geometry_type)
 
-            return MetaResponse(False, item_id, item_name)
+            return MetaResponse(False, item_id, item_name, geometry_type)
 
-        item_id, item_name = self.data
+        item_id, item_name, geometry_type = self.data
         response = True
 
-        if not item_id and not item_name:
-            response = False
-        elif not item_id:
-            response = 'missing item id'
+        if not item_id and not item_name and not geometry_type:
+            return MetaResponse(response, item_id, item_name, geometry_type)
+        
+        errors = []
+        if not item_id:
+            errors.append('missing item id')
         elif not item_name:
-            response = 'missing item name'
-        #: TODO: add geometry type
-
-        self.data = MetaResponse(response, item_id, item_name)
+            errors.append('missing item name')
+        elif not geometry_type:
+            errors.append('missing geometry type')
+            
+        if len(errors) > 0:
+            response = ', '.join(errors)
+            
+        self.data = MetaResponse(response, item_id, item_name, geometry_type)
 
         return self.data
 

--- a/src/conductor/checks.py
+++ b/src/conductor/checks.py
@@ -178,7 +178,7 @@ class MetaTableChecker(TableChecker):
         """
         item_id = None
         item_name = None
-        geometry_Type = None
+        geometry_type = None
         MetaResponse = namedtuple('MetaResponse', 'exists item_id item_name geometry_type')
 
         TableChecker.get_data(self, (self.original_table))
@@ -192,8 +192,8 @@ class MetaTableChecker(TableChecker):
         response = True
 
         if not item_id and not item_name and not geometry_type:
-            return MetaResponse(response, item_id, item_name, geometry_type)
-        
+            return MetaResponse(False, item_id, item_name, geometry_type)
+
         errors = []
         if not item_id:
             errors.append('missing item id')
@@ -201,10 +201,10 @@ class MetaTableChecker(TableChecker):
             errors.append('missing item name')
         elif not geometry_type:
             errors.append('missing geometry type')
-            
+
         if len(errors) > 0:
             response = ', '.join(errors)
-            
+
         self.data = MetaResponse(response, item_id, item_name, geometry_type)
 
         return self.data
@@ -214,16 +214,25 @@ class MetaTableChecker(TableChecker):
         """overrides the basic grading
         """
         if add:
-            if not report_value.item_id and not report_value.item_name:
-                return ' |\n| - item id | :no_entry: |\n| - item name | :no_entry:'
-
+            grade = ''
             if not report_value.item_id:
-                return ' |\n| - item id | :no_entry: |\n| - item name | :+1:'
+                grade += ' |\n| - item id | :no_entry: |'
+            else:
+                grade += ' |\n| - item id | :+1: |'
 
             if not report_value.item_name:
-                return ' |\n| - item id | :+1: |\n| - item name | :no_entry:'
+                grade += ' |\n| - item name | :no_entry: |'
+            else:
+                grade += ' |\n| - item name | :+1: |'
 
-            return ' |\n| - item id | :+1: |\n| - item name | :+1:'
+            if not report_value.geometry_type:
+                grade += ' |\n| - geometry type | :no_entry: |'
+            else:
+                grade += ' |\n| - geometry type | :+1: |'
+
+            grade = grade.replace('| |', '|').rstrip(' |')
+
+            return grade
 
         #: deletions should not contain a row
         if report_value.exists:

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -161,7 +161,7 @@ def test_missing_item_id_returns_correct_string(mocker):
     mocker.patch('conductor.checks.TableChecker.get_data')
 
     patient = MetaTableChecker('sgid.fake.table', SECRETS['internalsgid'])
-    patient.data = (None, 'Agol Published Name')
+    patient.data = (None, 'Agol Published Name', 'geometry type')
 
     response = patient.exists()
 
@@ -172,17 +172,28 @@ def test_missing_item_name_returns_correct_string(mocker):
     mocker.patch('conductor.checks.TableChecker.get_data')
 
     patient = MetaTableChecker('sgid.fake.table', SECRETS['internalsgid'])
-    patient.data = ('some-guid', None)
+    patient.data = ('some-guid', None, 'geometry type')
 
     response = patient.exists()
 
     assert response.exists == 'missing item name'
 
 
-def test_missing_both_returns_correct_string(mocker):
+def test_missing_geometry_type_returns_correct_string(mocker):
+    mocker.patch('conductor.checks.TableChecker.get_data')
+
+    patient = MetaTableChecker('sgid.fake.table', SECRETS['internalsgid'])
+    patient.data = ('some-guid', 'agol name', None)
+
+    response = patient.exists()
+
+    assert response.exists == 'missing geometry type'
+
+
+def test_missing_all_returns_correct_string(mocker):
     mocker.patch('conductor.checks.TableChecker.get_data')
     patient = MetaTableChecker('sgid.fake.table', SECRETS['internalsgid'])
-    patient.data = (None, None)
+    patient.data = (None, None, None)
 
     response = patient.exists()
 

--- a/tests/test_conductor.py
+++ b/tests/test_conductor.py
@@ -373,9 +373,10 @@ def test_table_checker_grade_integration_remove_fail(mocker):
 
 
 def test_metatable_checker_grade_integration_add_success(mocker):
-    MetaResponse = namedtuple('MetaResponse', 'exists item_id item_name')
+    MetaResponse = namedtuple('MetaResponse', 'exists item_id item_name geometry_type')
     Grade = namedtuple('Grade', 'check grade issue')
-    grade = MetaTableChecker('table.name', {}).grade(add=True, report_value=MetaResponse(True, 'item id', 'item name'))
+    grade = MetaTableChecker('table.name', {}
+                            ).grade(add=True, report_value=MetaResponse(True, 'item id', 'item name', 'geometry type'))
 
     attributes = {}
     issue = Issue(REQUESTER, {}, attributes, True)
@@ -390,14 +391,15 @@ def test_metatable_checker_grade_integration_add_success(mocker):
 | - | :-: |
 | meta table |  |
 | - item id | :+1: |
-| - item name | :+1: |'''
+| - item name | :+1: |
+| - geometry type | :+1: |'''
     )
 
 
 def test_metatable_checker_grade_integration_add_mixed(mocker):
-    MetaResponse = namedtuple('MetaResponse', 'exists item_id item_name')
+    MetaResponse = namedtuple('MetaResponse', 'exists item_id item_name geometry_type')
     Grade = namedtuple('Grade', 'check grade issue')
-    grade = MetaTableChecker('table.name', {}).grade(add=True, report_value=MetaResponse(True, None, 'item name'))
+    grade = MetaTableChecker('table.name', {}).grade(add=True, report_value=MetaResponse(True, None, 'item name', None))
 
     attributes = {}
     issue = Issue(REQUESTER, {}, attributes, True)
@@ -412,14 +414,15 @@ def test_metatable_checker_grade_integration_add_mixed(mocker):
 | - | :-: |
 | meta table |  |
 | - item id | :no_entry: |
-| - item name | :+1: |'''
+| - item name | :+1: |
+| - geometry type | :no_entry: |'''
     )
 
 
 def test_metatable_checker_grade_integration_add_mixed_2(mocker):
-    MetaResponse = namedtuple('MetaResponse', 'exists item_id item_name')
+    MetaResponse = namedtuple('MetaResponse', 'exists item_id item_name geometry_type')
     Grade = namedtuple('Grade', 'check grade issue')
-    grade = MetaTableChecker('table.name', {}).grade(add=True, report_value=MetaResponse(True, 'item id', None))
+    grade = MetaTableChecker('table.name', {}).grade(add=True, report_value=MetaResponse(True, 'item id', None, None))
 
     attributes = {}
     issue = Issue(REQUESTER, {}, attributes, True)
@@ -434,14 +437,15 @@ def test_metatable_checker_grade_integration_add_mixed_2(mocker):
 | - | :-: |
 | meta table |  |
 | - item id | :+1: |
-| - item name | :no_entry: |'''
+| - item name | :no_entry: |
+| - geometry type | :no_entry: |'''
     )
 
 
 def test_metatable_checker_grade_integration_add_fail(mocker):
-    MetaResponse = namedtuple('MetaResponse', 'exists item_id item_name')
+    MetaResponse = namedtuple('MetaResponse', 'exists item_id item_name geometry_type')
     Grade = namedtuple('Grade', 'check grade issue')
-    grade = MetaTableChecker('table.name', {}).grade(add=True, report_value=MetaResponse(True, None, None))
+    grade = MetaTableChecker('table.name', {}).grade(add=True, report_value=MetaResponse(True, None, None, None))
 
     attributes = {}
     issue = Issue(REQUESTER, {}, attributes, True)
@@ -456,14 +460,15 @@ def test_metatable_checker_grade_integration_add_fail(mocker):
 | - | :-: |
 | meta table |  |
 | - item id | :no_entry: |
-| - item name | :no_entry: |'''
+| - item name | :no_entry: |
+| - geometry type | :no_entry: |'''
     )
 
 
 def test_metatable_checker_grade_integration_remove_success(mocker):
-    MetaResponse = namedtuple('MetaResponse', 'exists item_id item_name')
+    MetaResponse = namedtuple('MetaResponse', 'exists item_id item_name geometry_type')
     Grade = namedtuple('Grade', 'check grade issue')
-    grade = MetaTableChecker('table.name', {}).grade(add=False, report_value=MetaResponse(False, None, None))
+    grade = MetaTableChecker('table.name', {}).grade(add=False, report_value=MetaResponse(False, None, None, None))
 
     attributes = {}
     issue = Issue(REQUESTER, {}, attributes, True)
@@ -481,9 +486,9 @@ def test_metatable_checker_grade_integration_remove_success(mocker):
 
 
 def test_metatable_checker_grade_integration_remove_fail(mocker):
-    MetaResponse = namedtuple('MetaResponse', 'exists item_id item_name')
+    MetaResponse = namedtuple('MetaResponse', 'exists item_id item_name geometry_type')
     Grade = namedtuple('Grade', 'check grade issue')
-    grade = MetaTableChecker('table.name', {}).grade(add=False, report_value=MetaResponse(True, None, None))
+    grade = MetaTableChecker('table.name', {}).grade(add=False, report_value=MetaResponse(True, None, None, None))
 
     attributes = {}
     issue = Issue(REQUESTER, {}, attributes, True)


### PR DESCRIPTION
the geometry type is used by cloudb to create the correct geometry type otherwise it fails.