### PR TITLE
feat: add migration block

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-deprecate-sgid-dataset.md
+++ b/.github/ISSUE_TEMPLATE/2-deprecate-sgid-dataset.md
@@ -14,6 +14,10 @@ assignees: "@steveoh, @gregbunce, @rkelson"
 
 _A short summary of the situation._
 
+## Migration Guide
+
+_A short summary of how users affected by this deprecation can modify their workflows and projects to continue to get similar or improved functionality_
+
 ## Action items
 
 1. _Assign a person who should complete the task by replacing `name` with their github `@name`._

--- a/.github/ISSUE_TEMPLATE/2-deprecate-sgid-dataset.md
+++ b/.github/ISSUE_TEMPLATE/2-deprecate-sgid-dataset.md
@@ -18,6 +18,11 @@ _A short summary of the situation._
 
 _A short summary of how users affected by this deprecation can modify their workflows and projects to continue to get similar or improved functionality_
 
+<!-- this is here to help the writing juices flow. feel free to completely replace this or simply fill in the blanks -->
+
+This dataset has ben replaced by () which is named () in the Open SGID and () in the SGID Open Data. 
+The replaced data is still accessible via our shelved policy in AGOL (a link to the shelved item).
+
 ## Action items
 
 1. _Assign a person who should complete the task by replacing `name` with their github `@name`._


### PR DESCRIPTION
i think this is a good block to have for deprecations that we can point folks to and persist instead of only being available in tweets etc.