### PR TITLE
fix: remove google drive data task

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-deprecate-sgid-dataset.md
+++ b/.github/ISSUE_TEMPLATE/2-deprecate-sgid-dataset.md
@@ -64,7 +64,6 @@ _Hard deletes are final. It is recommended to complete the soft delete process b
   - cut and paste row to `AGOLItems_shelved` table if shelving (see below)
   - set the `AGOL_ITEM_ID` field to `hosted by <agency>` for Farm from AGOL
   - set the `AGOL_ITEM_ID` field to `exclude from AGOL` to not publish to ArcGIS Online
-- [ ] Delete Google Drive data (name, completed: `2022/00/00`)
 - [ ] Remove row from `SGID.META.ChangeDetection` (name, completed: `2022/00/00`)
 - [ ] Remove data from forklift hashing and receiving (name, completed: `2022/00/00`)
 - [ ] Remove row from `data/hashed/changedetection.gdb/TableHashes` (name, completed: `2022/00/00`)


### PR DESCRIPTION
All Google Drive data was deleted as part of the [deprecation of Backseat Driver](#136).