### PR TITLE
feat: add NG911 check for deprecation template

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-deprecate-sgid-dataset.md
+++ b/.github/ISSUE_TEMPLATE/2-deprecate-sgid-dataset.md
@@ -93,8 +93,10 @@ _Add record to table._
 
 ## Are there service dependencies
 
-- Does an application depend on this data?
-- Are clients querying this data with the WebAPI?
+- [ ] Does an application depend on this data?
+- [ ] Are clients querying this data with the WebAPI?
+- [ ] Is this data used in the Next-Generation 911 Motorola Aware Map? (@eneemann on `2022/00/00`)
+    - If so, notify Josh Nielson (josh.nielson at motorolasolutions.com)
 
 ## Notification
 

--- a/.github/ISSUE_TEMPLATE/2-deprecate-sgid-dataset.md
+++ b/.github/ISSUE_TEMPLATE/2-deprecate-sgid-dataset.md
@@ -93,10 +93,9 @@ _Add record to table._
 
 ## Are there service dependencies
 
-- [ ] Does an application depend on this data?
 - [ ] Are clients querying this data with the WebAPI?
-- [ ] Is this data used in the Next-Generation 911 Motorola Aware Map? (@eneemann on `2023/00/00`)
-    - If so, notify Josh Nielson (josh.nielson at motorolasolutions.com)
+- [ ] Notify Josh Nielson (josh.nielson at motorolasolutions.com) if the data is in the Next-Generation 911 Motorola Aware Map? (@eneemann on `2023/00/00`)
+- [ ] Does any other application depend on this data?
 
 ## Notification
 

--- a/.github/ISSUE_TEMPLATE/2-deprecate-sgid-dataset.md
+++ b/.github/ISSUE_TEMPLATE/2-deprecate-sgid-dataset.md
@@ -95,7 +95,7 @@ _Add record to table._
 
 - [ ] Does an application depend on this data?
 - [ ] Are clients querying this data with the WebAPI?
-- [ ] Is this data used in the Next-Generation 911 Motorola Aware Map? (@eneemann on `2022/00/00`)
+- [ ] Is this data used in the Next-Generation 911 Motorola Aware Map? (@eneemann on `2023/00/00`)
     - If so, notify Josh Nielson (josh.nielson at motorolasolutions.com)
 
 ## Notification


### PR DESCRIPTION
A checkbox was added to the deprecation template to verify that the data layer is not used in the NG911 Motorola Aware application.  I'll handle this check because I maintain most of the NG911 data layers in the Aware Map.