### PR TITLE
fix: auditor's role in deprecations

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-deprecate-sgid-dataset.md
+++ b/.github/ISSUE_TEMPLATE/2-deprecate-sgid-dataset.md
@@ -35,14 +35,14 @@ _The purpose of the soft delete is to ensure that all of our users and applicati
 
 Note: If this dataset is being replaced, then wait until the new data is publicly available before completing these steps:
 
-- [ ] Append "(Mature Support)" to the end of the item title (name, completed: `2022/00/00`)
-- [ ] Remove all tags other than "Deprecated" (name, completed: `2022/00/00`)
-- [ ] Add note to ArcGIS Online description noting when layer will be deleted and any replacement layer (name, completed: `2022/00/00`)
-- [ ] Unshare item from Open Data (name, completed: `2022/00/00`)
+- [ ] Append "(Mature Support)" to the end of the item title in the `SGID.META.AGOLItems` table (name, completed: `2022/00/00`)
+- [ ] Remove all tags other than "Deprecated" in the SDE metadata (name, completed: `2022/00/00`)
+- [ ] Add note to SDE description noting when layer will be deleted and any replacement layer (name, completed: `2022/00/00`)
 - [ ] Update the [SGID Index](https://docs.google.com/spreadsheets/d/11ASS7LnxgpnD0jN4utzklREgMf1pcvYjcXcIcESHweQ/edit#gid=1) row as deprecated by pasting the related Porter issue URL in the Deprecated field (name, completed: `2022/00/00`)
-- [ ] Mark ArcGIS Online item as deprecated in preparation for future deletion (name, completed: `2022/00/00`)
-  - [ ] Change `Authoritative` field to `d` in `SGID.META.AGOLItems` to automatically set the `Deprecated` AGOL flag. Allow the `d` to persist through one run of [Auditor](https://github.com/agrc/auditor) - currently, Auditor runs daily at 5:00am (name, completed: `2022/00/00`)
-    - [ ] After one successful run of Auditor, remove the row from the `SGID.META.AGOLItems` table. This will trigger the removal of this item in Open SGID (name, completed: `2022/00/00`)
+- [ ] Change `Authoritative` field to `d` in `SGID.META.AGOLItems` to automatically set the `Deprecated` AGOL flag. Allow the `d` to persist through one run of [Auditor](https://github.com/agrc/auditor) - currently, Auditor runs daily at 5:00am (name, completed: `2022/00/00`)
+  - After at least one successful run of Auditor:
+    - [ ] Remove the row from the `SGID.META.AGOLItems` table. This will trigger the removal of this item in Open SGID (name, completed: `2022/00/00`)
+    - [ ] Unshare the item from its SGID group, which will remove it from Open Data (name, completed: `2022/00/00`)
 
 ### Hard Delete
 
@@ -52,7 +52,7 @@ _Hard deletes are final. It is recommended to complete the soft delete process b
   - Deprecated database layers can be backup up on Google Drive > AGRC Share > Team Projects > SGID > [deprecated layers]
 - [ ] Remove ArcGIS Online item: (name, completed: `2022/00/00`)
   - Manually delete the AGOL item
-  -  -OR-
+  - -OR-
   - Unshare by changing the `AGOL_ITEM_ID` field in `SGID.META.AGOLItems` to something other than an Item ID and manaually changing the sharing settings (remove the item from all SGID groups, remove Public sharing),
   - -OR-
   - Shelve the data by copying the row from `SGID.META.AGOLItems` to the `AGOLItems_shelved` table in AGOL and changing the `AGOL_ITEM_ID` field in `SGID.META.AGOLItems` to `shelved` or some other note.

--- a/.github/ISSUE_TEMPLATE/2-deprecate-sgid-dataset.md
+++ b/.github/ISSUE_TEMPLATE/2-deprecate-sgid-dataset.md
@@ -35,51 +35,51 @@ _The purpose of the soft delete is to ensure that all of our users and applicati
 
 Note: If this dataset is being replaced, then wait until the new data is publicly available before completing these steps:
 
-- [ ] Append "(Mature Support)" to the end of the item title in the `SGID.META.AGOLItems` table (name, completed: `2022/00/00`)
-- [ ] Remove all tags other than "Deprecated" in the SDE metadata (name, completed: `2022/00/00`)
-- [ ] Add note to SDE description noting when layer will be deleted and any replacement layer (name, completed: `2022/00/00`)
-- [ ] Update the [SGID Index](https://docs.google.com/spreadsheets/d/11ASS7LnxgpnD0jN4utzklREgMf1pcvYjcXcIcESHweQ/edit#gid=1) row as deprecated by pasting the related Porter issue URL in the Deprecated field (name, completed: `2022/00/00`)
-- [ ] Change `Authoritative` field to `d` in `SGID.META.AGOLItems` to automatically set the `Deprecated` AGOL flag. Allow the `d` to persist through one run of [Auditor](https://github.com/agrc/auditor) - currently, Auditor runs daily at 5:00am (name, completed: `2022/00/00`)
+- [ ] Append "(Mature Support)" to the end of the item title in the `SGID.META.AGOLItems` table (name, completed: `2023/00/00`)
+- [ ] Remove all tags other than "Deprecated" in the SDE metadata (name, completed: `2023/00/00`)
+- [ ] Add note to SDE description noting when layer will be deleted and any replacement layer (name, completed: `2023/00/00`)
+- [ ] Update the [SGID Index](https://docs.google.com/spreadsheets/d/11ASS7LnxgpnD0jN4utzklREgMf1pcvYjcXcIcESHweQ/edit#gid=1) row as deprecated by pasting the related Porter issue URL in the Deprecated field (name, completed: `2023/00/00`)
+- [ ] Change `Authoritative` field to `d` in `SGID.META.AGOLItems` to automatically set the `Deprecated` AGOL flag. Allow the `d` to persist through one run of [Auditor](https://github.com/agrc/auditor) - currently, Auditor runs daily at 5:00am (name, completed: `2023/00/00`)
   - After at least one successful run of Auditor:
-    - [ ] Remove the row from the `SGID.META.AGOLItems` table. This will trigger the removal of this item in Open SGID (name, completed: `2022/00/00`)
-    - [ ] Unshare the item from its SGID group, which will remove it from Open Data (name, completed: `2022/00/00`)
+    - [ ] Remove the row from the `SGID.META.AGOLItems` table. This will trigger the removal of this item in Open SGID (name, completed: `2023/00/00`)
+    - [ ] Unshare the item from its SGID group, which will remove it from Open Data (name, completed: `2023/00/00`)
 
 ### Hard Delete
 
 _Hard deletes are final. It is recommended to complete the soft delete process before moving on to these steps. If you decide to skip the soft delete, note that you will need to incorporate some of those steps here._
 
-- [ ] Manually remove data from the Internal SGID (name, completed: `2022/00/00`)
+- [ ] Manually remove data from the Internal SGID (name, completed: `2023/00/00`)
   - Deprecated database layers can be backup up on Google Drive > AGRC Share > Team Projects > SGID > [deprecated layers]
-- [ ] Remove ArcGIS Online item: (name, completed: `2022/00/00`)
+- [ ] Remove ArcGIS Online item: (name, completed: `2023/00/00`)
   - Manually delete the AGOL item
   - -OR-
   - Unshare by changing the `AGOL_ITEM_ID` field in `SGID.META.AGOLItems` to something other than an Item ID and manaually changing the sharing settings (remove the item from all SGID groups, remove Public sharing),
   - -OR-
   - Shelve the data by copying the row from `SGID.META.AGOLItems` to the `AGOLItems_shelved` table in AGOL and changing the `AGOL_ITEM_ID` field in `SGID.META.AGOLItems` to `shelved` or some other note.
   - Deprecated AGOL items can be backup on Google Drive > AGRC Share > Team Projects > SGID > [deprecated layers](https://drive.google.com/drive/u/1/folders/1JT4XzZz3wX95nJc95iOcQ2T3Zd_4GtAS).
-- [ ] Remove Farm from AGOL connection (name, completed: `2022/00/00`)
-- [ ] Update relevant [gis.utah.gov](https://gis.utah.gov/data) data pages (name, completed: `2022/00/00`)
-- [ ] Add this porter url to the `Deprecated` field of the [Stewardship](https://docs.google.com/spreadsheets/d/11ASS7LnxgpnD0jN4utzklREgMf1pcvYjcXcIcESHweQ/edit#gid=1) record (name, completed: `2022/00/00`)
-- [ ] Update `SGID.META.AGOLItems` table (name, completed: `2022/00/00`)
+- [ ] Remove Farm from AGOL connection (name, completed: `2023/00/00`)
+- [ ] Update relevant [gis.utah.gov](https://gis.utah.gov/data) data pages (name, completed: `2023/00/00`)
+- [ ] Add this porter url to the `Deprecated` field of the [Stewardship](https://docs.google.com/spreadsheets/d/11ASS7LnxgpnD0jN4utzklREgMf1pcvYjcXcIcESHweQ/edit#gid=1) record (name, completed: `2023/00/00`)
+- [ ] Update `SGID.META.AGOLItems` table (name, completed: `2023/00/00`)
   - cut and paste row to `AGOLItems_shelved` table if shelving (see below)
   - set the `AGOL_ITEM_ID` field to `hosted by <agency>` for Farm from AGOL
   - set the `AGOL_ITEM_ID` field to `exclude from AGOL` to not publish to ArcGIS Online
-- [ ] Delete Google Drive data (name, completed: `2022/00/00`)
-- [ ] Remove row from `SGID.META.ChangeDetection` (name, completed: `2022/00/00`)
-- [ ] Remove data from forklift hashing and receiving (name, completed: `2022/00/00`)
-- [ ] Remove row from `data/hashed/changedetection.gdb/TableHashes` (name, completed: `2022/00/00`)
+- [ ] Delete Google Drive data (name, completed: `2023/00/00`)
+- [ ] Remove row from `SGID.META.ChangeDetection` (name, completed: `2023/00/00`)
+- [ ] Remove data from forklift hashing and receiving (name, completed: `2023/00/00`)
+- [ ] Remove row from `data/hashed/changedetection.gdb/TableHashes` (name, completed: `2023/00/00`)
 
 ### Shelve/Static
 
 _Choose one based on situation._
 
-- [ ] Upload to `UtahAGRC/AGRC_Shelved` folder in AGOL (New shelved item not already in AGOL) (name, completed: `2022/00/00`)
-- [ ] Move existing AGOL item to `AGRC_Shelved` AGOL folder (shelving an item already in AGOL) (name, completed: `2022/00/00`)
-- [ ] Upload to appropriate `UtahAGRC/{SGID Category}` folder in AGOL (for `static` datasets) (name, completed: `2022/00/00`)
+- [ ] Upload to `UtahAGRC/AGRC_Shelved` folder in AGOL (New shelved item not already in AGOL) (name, completed: `2023/00/00`)
+- [ ] Move existing AGOL item to `AGRC_Shelved` AGOL folder (shelving an item already in AGOL) (name, completed: `2023/00/00`)
+- [ ] Upload to appropriate `UtahAGRC/{SGID Category}` folder in AGOL (for `static` datasets) (name, completed: `2023/00/00`)
 
 _Add record to table._
 
-- [ ] Add record to `AGOLItems_shelved` [table](https://utah.maps.arcgis.com/home/item.html?id=1760fbedbc7e49429aa6c0c3ab1442ec) in ArcGIS Online  with `shelved` or `static` in the `CATEGORY` field (name, completed: `2022/00/00`)
+- [ ] Add record to `AGOLItems_shelved` [table](https://utah.maps.arcgis.com/home/item.html?id=1760fbedbc7e49429aa6c0c3ab1442ec) in ArcGIS Online  with `shelved` or `static` in the `CATEGORY` field (name, completed: `2023/00/00`)
 
 ## :robot: Automation validation
 
@@ -87,9 +87,9 @@ _Add record to table._
 1. _Check [x] the box and add the date of verification `2020/01/01` when the task is verified._
 1. _~Strike~ out all items that do not apply._
 
-- [ ] Remove data from Open SGID (name on `2022/00/00`)
-- [ ] [sgid-index](https://gis.utah.gov/data/sgid-index) (@steveoh on `2022/00/00`)
-- [ ] Auditor sets appropriate `shelved`/`static`/`Deprecated` information (@jacobdadams on `2022/00/00`)
+- [ ] Remove data from Open SGID (name on `2023/00/00`)
+- [ ] [sgid-index](https://gis.utah.gov/data/sgid-index) (@steveoh on `2023/00/00`)
+- [ ] Auditor sets appropriate `shelved`/`static`/`Deprecated` information (@jacobdadams on `2023/00/00`)
 
 ## Are there service dependencies
 


### PR DESCRIPTION
~Currently, we set auditor deprecated and let it run once. This overwrites all the work done in the previous check boxes because Auditor applies all the metadata from the internal SDE. Since we're already performing AGOL work manually, it makes sense to remove auditor from the equation (by deleting the row from the meta table) and set the deprecated setting manually.~