### PR TITLE
fix: increase cloud run timeout

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -105,7 +105,7 @@ runs:
           --max-instances=10
           --cpu=1000m
           --memory=512Mi
-          --timeout=5m
+          --timeout=10m
 
     - name: 🕰️ Create Cloud Scheduler
       shell: bash


### PR DESCRIPTION
"The request has been terminated because it has reached the maximum request timeout."