### PR TITLE
fix: bump memory for cloud run function

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -104,7 +104,7 @@ runs:
           --vpc-egress=all-traffic
           --max-instances=10
           --cpu=1000m
-          --memory=512Mi
+          --memory=1Gi
           --timeout=10m
 
     - name: 🕰️ Create Cloud Scheduler


### PR DESCRIPTION
Monitoring alerts show that the function ran out of memory this morning.