### PR TITLE
feat: automatically set the complete date for porter task checkboxes

### DIFF
--- a/.github/scripts/issue_edit.mjs
+++ b/.github/scripts/issue_edit.mjs
@@ -1,0 +1,48 @@
+const CHECKED_TASK_PATTERN = /^\s*[-*]\s*\[[xX]\]\s+/;
+const PLACEHOLDER_DATE_PATTERN = /`\d{4}\/00\/00`/;
+const COMPLETED_PATTERN =
+  /(\([^\n)]*,\s*completed:\s*)`\d{4}\/\d{2}\/\d{2}`(\))/;
+const VERIFIED_PATTERN = /(\([^\n)]*\s+on\s*)`\d{4}\/\d{2}\/\d{2}`(\))/;
+
+export function isCheckedTask(line) {
+  return CHECKED_TASK_PATTERN.test(line);
+}
+
+export function isStruckThroughTask(line) {
+  return /~\s*$/.test(line) || /^\s*~.*~\s*$/.test(line);
+}
+
+export function hasPlaceholderDate(line) {
+  return PLACEHOLDER_DATE_PATTERN.test(line);
+}
+
+export function applyCompletionDate(line, currentDate) {
+  const completedLine = line.replace(
+    COMPLETED_PATTERN,
+    `$1\`${currentDate}\`$2`,
+  );
+
+  if (completedLine !== line) {
+    return completedLine;
+  }
+
+  return line.replace(VERIFIED_PATTERN, `$1\`${currentDate}\`$2`);
+}
+
+export function getUpdatedIssueBody({ currentBody, currentDate }) {
+  const currentLines = currentBody.split("\n");
+
+  const updatedLines = currentLines.map((currentLine) => {
+    if (
+      !isCheckedTask(currentLine) ||
+      isStruckThroughTask(currentLine) ||
+      !hasPlaceholderDate(currentLine)
+    ) {
+      return currentLine;
+    }
+
+    return applyCompletionDate(currentLine, currentDate);
+  });
+
+  return updatedLines.join("\n");
+}

--- a/.github/workflows/issue_edit.yml
+++ b/.github/workflows/issue_edit.yml
@@ -1,0 +1,82 @@
+name: Update Issue Task Completion Date
+
+on:
+  issues:
+    types: [edited]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  update-completion-dates:
+    if: ${{ !github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ⬇️ Check out code
+        uses: actions/checkout@v6
+        with:
+          show-progress: false
+
+      - name: Update checked task completion dates
+        uses: actions/github-script@v8
+        with:
+          retries: 3
+          script: |
+            const { getUpdatedIssueBody } = await import('./.github/scripts/issue_edit.mjs')
+            const issue = context.payload.issue
+            const maxAttempts = 3
+            const retryableStatuses = new Set([409, 422, 500, 502, 503, 504])
+
+            const formatter = new Intl.DateTimeFormat('en-CA', {
+              timeZone: 'America/Denver',
+              year: 'numeric',
+              month: '2-digit',
+              day: '2-digit',
+            })
+
+            const currentDate = formatter.format(new Date()).replace(/-/g, '/')
+
+            for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+              const latestIssue = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+              })
+
+              const currentBody = latestIssue.data.body || ''
+
+              const updatedBody = getUpdatedIssueBody({
+                currentBody,
+                currentDate,
+              })
+
+              if (updatedBody === currentBody) {
+                core.info('No completion dates needed to be updated.')
+                return
+              }
+
+              try {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: updatedBody,
+                })
+
+                core.info(`Updated completion dates for issue #${issue.number} on attempt ${attempt}.`)
+                return
+              } catch (error) {
+                const status = error.status ?? 0
+
+                if (attempt === maxAttempts || !retryableStatuses.has(status)) {
+                  throw error
+                }
+
+                core.warning(`Attempt ${attempt} failed with status ${status}. Retrying with the latest issue body.`)
+              }
+            }

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "src/conductor/**"
       - "tests/**"
+      - ".github/scripts/**"
       - ".github/workflows/*.yml"
       - "setup.py"
 
@@ -24,6 +25,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           show-progress: false
+
+      - name: ⬢ Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: latest
+
+      - name: 🧪 Run workflow unit tests
+        run: node --test tests/issue_edit.test.mjs
 
       - name: 🐍 Set up Python
         uses: actions/setup-python@v6

--- a/README.md
+++ b/README.md
@@ -16,12 +16,23 @@ UGRC tracks the additions, replacements, and deletions of SGID items (in the bro
 1. The triagers will choose which items need to be handled and tag the appropriate people to handle them:
    - [ ] ArcGIS Online (@jacobdadams)
    - Items that don't need to be handled should be struck through (wrap the line with `~`'s) instead of being deleted:
-      - `~ArcGISOnline (assigned to)~` (note there are no spaces between the `~`'s and the text to be struck out)
+     - `~ArcGISOnline (assigned to)~` (note there are no spaces between the `~`'s and the text to be struck out)
    - Once the triager has identified any steps required for their team or made any relevant comments, they should check the box in the triage section to indicate that their triage is complete:
-      - [x] Data Team Triage (@gregbunce)
+     - [x] Data Team Triage (@gregbunce)
 1. The people assigned to different issues will check the boxes as they are completed and comment on the issue to notify the rest of the group:
    - [x] ArcGIS Online (@jacobdadams)
 1. Once all boxes are checked, the person who first opened the issue should close it.
+
+## Task Completion Dates
+
+Porter issue templates include task lines with placeholder completion dates, such as:
+
+- [ ] Data Team Triage (name, completed: `2026/00/00`)
+- [ ] Validation review (name on `2026/00/00`)
+
+When one of these Porter task lines is checked in an issue description, GitHub Actions automatically replaces the placeholder date with the current date in the `America/Denver` timezone.
+
+This automation only updates Porter-style checked task lines that still contain a placeholder date. It does not update unchecked tasks, struck-through tasks, or tasks that already have a real completion date. If a box is unchecked later, the existing completion date is left in place.
 
 ## Data Flow for New SGID Datasets
 
@@ -62,7 +73,6 @@ https://github.com/agrc/porter/issues/#
 #### intent to add
 
 ```md
-
 🌱🌱The SGID is growing🌳🌳
 
 Dataset from Agency coming soon!
@@ -77,7 +87,6 @@ Follow along and comment if you are interested!
 #### addition complete
 
 ```md
-
 🌱🌱The SGID has grown🌳🌳
 
 Dataset from Agency is live in the SGID!

--- a/tests/issue_edit.test.mjs
+++ b/tests/issue_edit.test.mjs
@@ -1,0 +1,144 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { getUpdatedIssueBody } from "../.github/scripts/issue_edit.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+test("updates a completed task line with a placeholder date", () => {
+  const currentBody = "- [x] Append title (@stdavis, completed: `2026/00/00`)";
+
+  const updatedBody = getUpdatedIssueBody({
+    currentBody,
+    currentDate: "2026/04/13",
+  });
+
+  assert.equal(
+    updatedBody,
+    "- [x] Append title (@stdavis, completed: `2026/04/13`)",
+  );
+});
+
+test("updates a verification line with a placeholder date", () => {
+  const currentBody =
+    "- [x] [sgid-index](https://example.com) (@stdavis on `2026/00/00`)";
+
+  const updatedBody = getUpdatedIssueBody({
+    currentBody,
+    currentDate: "2026/04/13",
+  });
+
+  assert.equal(
+    updatedBody,
+    "- [x] [sgid-index](https://example.com) (@stdavis on `2026/04/13`)",
+  );
+});
+
+test("updates checked placeholder tasks even if they were already checked before the latest edit", () => {
+  const currentBody = "- [x] Append title (@stdavis, completed: `2026/00/00`)";
+
+  const updatedBody = getUpdatedIssueBody({
+    currentBody,
+    currentDate: "2026/04/13",
+  });
+
+  assert.equal(
+    updatedBody,
+    "- [x] Append title (@stdavis, completed: `2026/04/13`)",
+  );
+});
+
+test("updates multiple checked placeholder tasks in one pass", () => {
+  const currentBody = [
+    "- [x] Existing task (@stdavis, completed: `2026/00/00`)",
+    "- [x] New task (@stdavis, completed: `2026/00/00`)",
+  ].join("\n");
+
+  const updatedBody = getUpdatedIssueBody({
+    currentBody,
+    currentDate: "2026/04/13",
+  });
+
+  assert.equal(
+    updatedBody,
+    [
+      "- [x] Existing task (@stdavis, completed: `2026/04/13`)",
+      "- [x] New task (@stdavis, completed: `2026/04/13`)",
+    ].join("\n"),
+  );
+});
+
+test("does not update struck-through checked tasks", () => {
+  const currentBody = "~- [x] Ignore me (@stdavis, completed: `2026/00/00`)~";
+
+  const updatedBody = getUpdatedIssueBody({
+    currentBody,
+    currentDate: "2026/04/13",
+  });
+
+  assert.equal(updatedBody, currentBody);
+});
+
+test("does not update checked tasks without placeholder dates", () => {
+  const currentBody = "- [x] Append title (@stdavis, completed: `2026/03/12`)";
+
+  const updatedBody = getUpdatedIssueBody({
+    currentBody,
+    currentDate: "2026/04/13",
+  });
+
+  assert.equal(updatedBody, currentBody);
+});
+
+test("does not update unchecked tasks with placeholder dates", () => {
+  const currentBody = "- [ ] Append title (@stdavis, completed: `2026/00/00`)";
+
+  const updatedBody = getUpdatedIssueBody({
+    currentBody,
+    currentDate: "2026/04/13",
+  });
+
+  assert.equal(updatedBody, currentBody);
+});
+
+test("updates real Porter issue template content without touching unrelated placeholders", () => {
+  const templatePath = path.join(
+    __dirname,
+    "..",
+    ".github",
+    "ISSUE_TEMPLATE",
+    "6-deprecate-sgid-dataset.md",
+  );
+  const currentBody = fs
+    .readFileSync(templatePath, "utf8")
+    .replace(
+      '- [ ] Append "(Mature Support)" to the end of the item title in the `SGID.META.AGOLItems` table (name, completed: `2026/00/00`)',
+      '- [x] Append "(Mature Support)" to the end of the item title in the `SGID.META.AGOLItems` table (@stdavis, completed: `2026/00/00`)',
+    )
+    .replace(
+      "- [ ] [sgid-index](https://gis.utah.gov/products/sgid/sgid-index/) (@stdavis on `2026/00/00`)",
+      "- [x] [sgid-index](https://gis.utah.gov/products/sgid/sgid-index/) (@stdavis on `2026/00/00`)",
+    );
+
+  const updatedBody = getUpdatedIssueBody({
+    currentBody,
+    currentDate: "2026/04/13",
+  });
+
+  assert.match(
+    updatedBody,
+    /- \[x\] Append "\(Mature Support\)" to the end of the item title in the `SGID\.META\.AGOLItems` table \(@stdavis, completed: `2026\/04\/13`\)/,
+  );
+  assert.match(
+    updatedBody,
+    /- \[x\] \[sgid-index\]\(https:\/\/gis\.utah\.gov\/products\/sgid\/sgid-index\/\) \(@stdavis on `2026\/04\/13`\)/,
+  );
+  assert.match(
+    updatedBody,
+    /- \[ \] Remove all tags other than "Deprecated" in the SDE metadata \(name, completed: `2026\/00\/00`\)/,
+  );
+});


### PR DESCRIPTION
I think that this will make updating porter issues slightly nicer. Let me know what you think.